### PR TITLE
Fixed url on form when clicking search button

### DIFF
--- a/src/views/index.hbs
+++ b/src/views/index.hbs
@@ -1,6 +1,6 @@
 <div class="container text-center">
     <div class="col-md-6 col-md-offset-3">
-        <form action="/terms/">
+        <form action="/terms">
             <div class="form-group">
                 <div class="input-group">
                     <input class="form-control" name="search-term" placeholder="Enter a search term (ex. `CMS` or `NPN`)" autofocus />


### PR DESCRIPTION
Previously clicking search button requested localhost:3000/terms/.  However, the '/' on the end results in an invalid route.  Removed the '/'.  