### PR TITLE
Fix indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,23 +32,23 @@ gulp.task('clean', function () {
 })
 
 gulp.task('build', ['clean'], function () {
-	gulp.src('src/views/**')
-		.pipe(gulp.dest('build/views/'));
+    gulp.src('src/views/**')
+        .pipe(gulp.dest('build/views/'));
 
-	return gulp.src('src/**/*.js')
-		.pipe($.sourcemaps.init())
-		.pipe($.traceur({annotations:true, types:true, typeAssertions:true, typeAssertionModule:'../assert'}))
-		.pipe($.sourcemaps.write('.'))
-		.pipe(gulp.dest('build'))
+    return gulp.src('src/**/*.js')
+        .pipe($.sourcemaps.init())
+        .pipe($.traceur({annotations:true, types:true, typeAssertions:true, typeAssertionModule:'../assert'}))
+        .pipe($.sourcemaps.write('.'))
+        .pipe(gulp.dest('build'))
 })
 
 gulp.task('test', ['build'], function () {
-	return gulp.src('build/**/*Spec.js', {
-			read: false
-		})
-		.pipe($.mocha({
-			reporter: 'nyan'
-		}))
+    return gulp.src('build/**/*Spec.js', {
+            read: false
+        })
+        .pipe($.mocha({
+            reporter: 'nyan'
+        }))
 })
 
 function serve(isDev) {

--- a/migrations/1421262205073_create-initial-schema.js
+++ b/migrations/1421262205073_create-initial-schema.js
@@ -1,18 +1,18 @@
 exports.up = function(pgm, run) {
     pgm.createTable('terms',
             {
-                id: { type: 'serial', primaryKey: true, notNull: true}, 
+                id: { type: 'serial', primaryKey: true, notNull: true},
                 tags: { type: 'text'},
                 term: { type: 'varchar(100)', notNull: true}
             });
-    
+
     pgm.createTable('definitions', 
             {
                 id: { type: 'serial', primaryKey: true, notNull: true},
-                termid: { type: 'integer', foreignKey: true, notNull: true, references: 'terms'}, 
+                termid: { type: 'integer', foreignKey: true, notNull: true, references: 'terms'},
                 definition: { type: 'text', notNull: true}
             });
-    
+
     run();
 };
 

--- a/migrations/1421347043696_update-schema.js
+++ b/migrations/1421347043696_update-schema.js
@@ -1,8 +1,8 @@
 exports.up = function(pgm, run) {
     pgm.dropTable('definitions');
-    pgm.addColumns('terms', 
+    pgm.addColumns('terms',
         {   definition: { type: 'text' } });
-    
+
     run();
 };
 

--- a/migrations/1421353017882_terms-index-creation.js
+++ b/migrations/1421353017882_terms-index-creation.js
@@ -1,9 +1,9 @@
 exports.up = function(pgm, run) {
     pgm.sql("create index idx_terms on terms using gin((setweight(to_tsvector('english', term), 'A')||     setweight(to_tsvector('english', tags), 'B') || setweight(to_tsvector('english', definition), 'C')))");
-  run();
+    run();
 };
 
 exports.down = function(pgm, run) {
     pgm.sql("drop index idx_terms");
-  run();
+    run();
 };

--- a/migrations/1421698764836_terms-id-reset.js
+++ b/migrations/1421698764836_terms-id-reset.js
@@ -1,6 +1,6 @@
 exports.up = function(pgm, run) {
     pgm.sql("alter sequence terms_id_seq restart with 6");
-  run();
+    run();
 };
 
 exports.down = function(pgm, run) {

--- a/src/assert.js
+++ b/src/assert.js
@@ -1,46 +1,46 @@
 // https://github.com/google/traceur-compiler/blob/master/test/feature/TypeAssertions/resources/assert.js
 import chai from 'chai'
-    
+
 export var assert = chai.assert;
 
 assert.type = function (actual, type) {
-  if (type === $traceurRuntime.type.any) {
-    return actual;
-  }
-
-  if (type === $traceurRuntime.type.void) {
-    assert.isUndefined(actual);
-    return actual;
-  }
-
-  if ($traceurRuntime.type[type.name] === type) {
-    // chai.assert treats Number as number :'(
-    // Use runtime to handle symbol
-    assert.equal($traceurRuntime.typeof(actual), type.name);
-  } else if (type instanceof $traceurRuntime.GenericType) {
-    assert.type(actual, type.type);
-    if (type.type === Array) {
-      for (var i = 0; i < actual.length; i++) {
-        assert.type(actual[i], type.argumentTypes[0]);
-      }
-    } else {
-      throw new Error(`Unsupported generic type${type}`);
+    if (type === $traceurRuntime.type.any) {
+        return actual;
     }
-  } else {
-    assert.instanceOf(actual, type);
-  }
 
-  // TODO(arv): Handle more generics, structural types and more.
+    if (type === $traceurRuntime.type.void) {
+        assert.isUndefined(actual);
+        return actual;
+    }
 
-  return actual;
+    if ($traceurRuntime.type[type.name] === type) {
+        // chai.assert treats Number as number :'(
+        // Use runtime to handle symbol
+        assert.equal($traceurRuntime.typeof(actual), type.name);
+    } else if (type instanceof $traceurRuntime.GenericType) {
+        assert.type(actual, type.type);
+        if (type.type === Array) {
+            for (var i = 0; i < actual.length; i++) {
+                assert.type(actual[i], type.argumentTypes[0]);
+            }
+        } else {
+            throw new Error(`Unsupported generic type${type}`);
+        }
+    } else {
+        assert.instanceOf(actual, type);
+    }
+
+    // TODO(arv): Handle more generics, structural types and more.
+
+    return actual;
 };
 
 assert.argumentTypes = function(...params) {
-  for (var i = 0; i < params.length; i += 2) {
-    if (params[i + 1] !== null) {
-      assert.type(params[i], params[i + 1]);
+    for (var i = 0; i < params.length; i += 2) {
+        if (params[i + 1] !== null) {
+            assert.type(params[i], params[i + 1]);
+        }
     }
-  }
 };
 
 assert.returnType = assert.type;

--- a/src/controllers/Controller.js
+++ b/src/controllers/Controller.js
@@ -3,7 +3,7 @@ export default class Controller {
         this.router = router
         this.baseUrl = baseUrl
     }
-    
+
     get(relativeUrl, handler, name = null) {
         this.route('GET', this.url(relativeUrl), handler)
     }
@@ -45,7 +45,7 @@ export default class Controller {
             url = url.trimEnd('/')
         return url
     }
-    
+
     absoluteUrl(relativeUrl='') {
         console.log('asdf')
 //        console.log(this.router)

--- a/src/controllers/api/ApiController.js
+++ b/src/controllers/api/ApiController.js
@@ -1,13 +1,13 @@
 import Controller from '../Controller'
-import Siren from '../../siren/Siren'	
-    
+import Siren from '../../siren/Siren'
+
 export default class ApiController extends Controller {
-	constructor(router, baseUrl = '') {
-		baseUrl = '/api/' + baseUrl.trimBoth('/')
-		super(router, baseUrl)
+    constructor(router, baseUrl = '') {
+        baseUrl = '/api/' + baseUrl.trimBoth('/')
+        super(router, baseUrl)
         this.router = router
-	}
-    
+    }
+
     siren(entity) {
         //var url = super.absoluteUrl.bind(this, url)()
         var url = 'https://localhost:3000/api'

--- a/src/controllers/api/TermApiController.js
+++ b/src/controllers/api/TermApiController.js
@@ -1,7 +1,7 @@
 import ApiController from './ApiController'
 import Term from '../../models/Term'
 import Lazy from 'lazy.js'
-    
+
 var mock = [new Term(1, 'FMO', 'Field Marketing Organization'),
                new Term(2, 'CMS', 'Center for Medicare and Medicaid Services'),
                new Term(3,  'NIPR', 'National Insurance Producer Registry'),
@@ -9,23 +9,21 @@ var mock = [new Term(1, 'FMO', 'Field Marketing Organization'),
                new Term(5,  'NAIC', 'National Association of Insurance Commissioners')]
 
 export default class TermApiController extends ApiController {
-	constructor(router) {
-		super(router, '/terms')
-		this.get('/', this.all)
-		this.get('/{id}', this.byId)
-	}
+    constructor(router) {
+        super(router, '/terms')
+        this.get('/', this.all)
+        this.get('/{id}', this.byId)
+    }
 
-	all(request, reply) {
+    all(request, reply) {
         var siren = super.siren(mock)
-		reply(siren).type('application/vnd.siren+json')
-	}
+        reply(siren).type('application/vnd.siren+json')
+    }
 
-	byId(request, reply) {
-		var id = request.params.id
-        var term = Lazy(mock).filter(e=>e.id == id).first() 
+    byId(request, reply) {
+        var id = request.params.id
+        var term = Lazy(mock).filter(e=>e.id == id).first()
         var siren = super.siren(term)
-		return reply(siren).type('application/vnd.siren+json')
-	}
-
+        return reply(siren).type('application/vnd.siren+json')
+    }
 }
-

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -3,11 +3,11 @@ import TermsController from './TermsController'
 import TermApiController from './api/TermApiController'
 
 export default function register(server) {
-	
-	// Views
-	new HomeController(server)
-	new TermsController(server)
-	
-	// Api
-	new TermApiController(server)
+
+    // Views
+    new HomeController(server)
+    new TermsController(server)
+
+    // Api
+    new TermApiController(server)
 };

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -8,13 +8,13 @@ String.prototype.normalize = function(s) {
 };
 
 String.prototype.trimBoth = function(s) {
-	return this.replace(new RegExp("^" + s + "+|" + s + "+$", "gm"), "");
+    return this.replace(new RegExp("^" + s + "+|" + s + "+$", "gm"), "");
 }
 
 String.prototype.trimStart = function(s) {
-	return this.replace(new RegExp("^" + s + "+", "gm"), "");
+    return this.replace(new RegExp("^" + s + "+", "gm"), "");
 }
 
 String.prototype.trimEnd = function(s) {
-	return this.replace(new RegExp(s + "+$", "gm"), "")
+    return this.replace(new RegExp(s + "+$", "gm"), "")
 }

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,8 @@ function spawnServer(name, port, registerControllers, viewOptions) {
         port
     })
 
-	if (viewOptions)
-		server.views(viewOptions);
+    if (viewOptions)
+        server.views(viewOptions);
 
     server.ext('onRequest', function (request, reply) {
         var methodOverride = request.query['hapi_method'];
@@ -41,7 +41,7 @@ function spawnServer(name, port, registerControllers, viewOptions) {
     });
 
     registerControllers(server)
-    
+
     server.start(() => {
         console.log(name + ' server running at:', server.info.uri)
         outputRoutes(server)

--- a/src/models/Term.js
+++ b/src/models/Term.js
@@ -1,5 +1,5 @@
 import {Get, Post, Put, Patch, Delete} from '../siren/attributes'
-    
+
 @Get('terms/:id')
 export default class Term {
     constructor(id=0,term='',definition='',tags=[]) {
@@ -8,32 +8,32 @@ export default class Term {
         this.tags = tags
         this.definition = definition
     }
-    
+
     get id() {return this.id_ = this.id_ || 0 }
     set id(value:number) { this.id_ = value }
-    
+
     get term() { return this.term_ = this.term_ || '' }
     set term(value:string) { this.term_ = value}
-    
+
     get tags() { return this.tags_ = this.tags_ || []}
     set tags(value:Array<string>) { this.tags_ = value}
-    
+
     get definition() { return this.definition_ = this.definition_ || ''}
     set definition(value:string) { this.definition_ = value}
-    
+
     @Post('postUrl')
     postMethod() {
     }
-    
+
     @Put('putUrl')
     putMethod(a) {
     }
-    
+
     @Patch('patchUrl')
     patchMethod(b,c) {
     }
-    
-    @Delete('deleteUrl') 
+
+    @Delete('deleteUrl')
     deleteMethod(d,e,f) {
     }
 }

--- a/src/siren/SirenSpec.js
+++ b/src/siren/SirenSpec.js
@@ -4,7 +4,7 @@ import {
     Get, Post, Put, Patch, Delete
 }
 from './attributes'
-    
+
 import Term from '../models/Term'
 
 import Siren from './Siren'
@@ -133,7 +133,7 @@ describe('siren:', () => {
             siren.root.entities[0].properties.real.should.equal(1.2)
             siren.root.entities[0].properties.string.should.equal('a')
         })
-        
+
         it('do not expose any private properties or subentities', () => {
             function Entity() {
                 this._private = 1
@@ -215,7 +215,7 @@ describe('siren:', () => {
     })
 
     describe('links:', () => {
-        
+
         it('generated for every method decorated with Get attribute', () => {
             class Entity {
                 @Get('url')
@@ -243,12 +243,12 @@ describe('siren:', () => {
             siren.root.links[0].rel.should.deep.equal(['self'])
             siren.root.links.length.should.equal(1)
         })
-        
+
         it('links do not expose any private methods regardless of what they are decorated with', () => {
              class Entity {
                 @Get('url')
                 _method(x) {}
-            
+
                 @Get('url2')
                 method_(y) {}
             }
@@ -257,9 +257,9 @@ describe('siren:', () => {
            siren.root.links[0].rel.should.deep.equal(['self'])
             siren.root.links.length.should.equal(1)
         })
-        
+
         describe('self link:', () => {
-            
+
             it('entity contains a self link', () => {
                 function Entity() {}
                 var entity = new Entity()
@@ -293,7 +293,7 @@ describe('siren:', () => {
                 var siren2 = new Siren(entity2)
                 siren2.root.links[0].href.should.equal('url2')
 
-                class Entity3 { 
+                class Entity3 {
                     get entity() {return new Entity()}
                     get entity2() {return new Entity2()}
                 }
@@ -374,7 +374,7 @@ describe('siren:', () => {
             })
         })
     })
-    
+
     describe('actions:', () => {
         it('entity contains actions for every method decorated with Post, Put, Patch, or Delete attributes', () => {
             class Entity {
@@ -411,7 +411,7 @@ describe('siren:', () => {
             siren.root.actions[3].method.should.equal('DELETE')
             siren.root.actions[3].fields.should.be.empty
         })
-        
+
         it('entity contains action fields for every parameter of a decorated method', () => {
             class Entity {
                 @Post('post/url')
@@ -427,12 +427,12 @@ describe('siren:', () => {
            fields[2].name.should.equal('c')
            fields[3].name.should.equal('d')
         })
-        
+
         it('actions do not expose any private methods regardless of what they are decorated with', () => {
              class Entity {
                 @Post('url')
                 _method(x) {}
-            
+
                 @Post('url2')
                 method_(y) {}
             }


### PR DESCRIPTION
This PR normalizes indentation across all files to be four spaces. It also adds a .editorconfig file to specify that all future changes use spaces instead of tabs. You may need to install the [EditorConfig plugin](http://editorconfig.org/#download) for your editor of choice before it will respect the rules declared in .editorconfig.

![Spaces will always triumph because tabs are dumb.](https://i.imgur.com/8KZlT9J.png)

Fixes #40.