### PR TITLE
Fix invalid down-migration SQL-statement related to terms_id_seq

### DIFF
--- a/migrations/1421698764836_terms-id-reset.js
+++ b/migrations/1421698764836_terms-id-reset.js
@@ -4,6 +4,6 @@ exports.up = function(pgm, run) {
 };
 
 exports.down = function(pgm, run) {
-    pgm.sql("alter sequence term_id_seq restart with 1");
+    pgm.sql("alter sequence terms_id_seq restart with 1");
     run();
 };


### PR DESCRIPTION
Previous behavior referenced an unknown sequence.
This is related to [PR #36](https://github.com/ritterim/definely/pull/36) and [issue 33](https://github.com/ritterim/definely/issues/33).