### PR TITLE
Remove TravisCI->Heroku task which does not appear to run on Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,4 @@ deploy:
   app:
     master: ritterim-definely
   run:
-    - "npm install"
     - "./node_modules/.bin/pg-migrate up"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/ritterim/definely",
   "dependencies": {
     "bluebird": "^2.6.4",
+    "chai": "~1.10.0",
     "co": "^4.1.0",
     "gulp": "^3.8.10",
     "gulp-clean": "^0.3.1",
@@ -44,7 +45,6 @@
   },
   "devDependencies": {
     "node-inspector": "^0.8.3",
-    "chai": "~1.10.0",
     "sinon": "~1.12.2",
     "mocha-sinon": "~1.1.4",
     "gulp-mocha": "~2.0.0"


### PR DESCRIPTION
I suppose it's a lack of understanding of where TravisCI runs this command.
Also move npm-dendency into main-dependency block instead of as dev.-dependency.
This is related to the siren client which has a dependency on chai.