### PR TITLE
Fix XSS on term-detailed web client view

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,17 +4,7 @@ var $ = require('gulp-load-plugins')({
     lazy: true
 });
 
-
 gulp.task('default', ['serve-dev'])
-
-gulp.task('test', ['build'], function () {
-    return gulp.src('build/**/*Spec.js', {
-            read: false
-        })
-        .pipe($.mocha({
-            reporter: 'nyan'
-        }))
-})
 
 gulp.task('serve-dev', ['build'], function () {
     serve(true)
@@ -42,11 +32,19 @@ gulp.task('build', ['clean'], function () {
         .pipe(gulp.dest('build'))
 })
 
-gulp.task('test', ['build'], function () {
+gulp.task('test', ['build', 'tdd-tests'], function () {
     return gulp.src('build/**/*Spec.js', {
             read: false
         })
         .pipe($.mocha())
+})
+
+gulp.task('tdd-tests', ['build'], function() {
+    return gulp.src('build/**/*Tests.js', {
+        read: false
+    }).pipe($.mocha({
+        ui: 'tdd'
+    }));
 })
 
 function serve(isDev) {

--- a/src/database.js
+++ b/src/database.js
@@ -1,10 +1,12 @@
 import pg from 'pg';
 import Term from './models/Term'
+import Sanitize from './sanitize'
 
 export
 default class Database {
     constructor(connectionUri) {
         this.connectionUri = connectionUri;
+        this.sanitize = new Sanitize();
     };
 
     add(term, callback) {
@@ -27,6 +29,8 @@ default class Database {
     };
 
     find(id, callback) {
+        var self = this;
+
         pg.connect(this.connectionUri, function (err, client, done) {
             if (err) {
                 return console.error('Could not connect to postgres', err);
@@ -44,7 +48,7 @@ default class Database {
                     var term = null
                     if (result.rows.length > 0) {
                         var row = result.rows[0]
-                        term = new Term(row.id, row.term, row.definition, row.tags || undefined)
+                        term = new Term(row.id, row.term, self.sanitize.htmlSanitize(row.definition), row.tags || undefined)
                     }
                     callback(term);
                 });
@@ -52,6 +56,8 @@ default class Database {
     };
 
     search(searchTerm, callback) {
+        var self = this;
+
         pg.connect(this.connectionUri, function (err, client, done) {
             if (err) {
                 return console.error('Could not connect to postgres', err);
@@ -64,7 +70,7 @@ default class Database {
             if (!searchTerm) {
                 client.query('select id, term, tags, definition from terms', function (err, result) {
 
-                    var terms = result.rows.map(row => new Term(row.id, row.term, row.definition, row.tags || undefined))
+                    var terms = result.rows.map(row => new Term(row.id, row.term, self.sanitize.htmlSanitize(row.definition), row.tags || undefined))
                     callback(terms)
                 })
             } else {
@@ -76,7 +82,7 @@ default class Database {
                         }
 
                         done();
-                        var terms = result.rows.map(row => new Term(row.id, row.term, row.definition, row.tags || undefined))
+                        var terms = result.rows.map(row => new Term(row.id, row.term, self.sanitize.htmlSanitize(row.definition), row.tags || undefined))
                         callback(terms);
                     })
             }

--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -1,0 +1,15 @@
+export default class Sanitize {
+    constructor() {
+    }
+
+    /**
+     * This function replaces all instances of lt and gt with their
+     * HTML entity.
+     */
+    htmlSanitize(html) {
+        html = html.replace(/</g, '&lt;');
+        html = html.replace(/>/g, '&gt;');
+
+        return html;
+    }
+}

--- a/src/sanitizeTests.js
+++ b/src/sanitizeTests.js
@@ -1,0 +1,13 @@
+import assert from 'assert'
+import sut from './sanitize'
+
+suite('Sanitize', function() {
+    suite('#htmlSanitize()', function() {
+        test('should encode all lt and gt-symbols', function() {
+            var result = new sut()
+                .htmlSanitize('<test></test>');
+
+            assert.equal('&lt;test&gt;&lt;/test&gt;', result);
+        });
+    });
+});


### PR DESCRIPTION
Previous behavior would render unencoded HTML in the view based on the term's definition-data.
New behavior encodes HTML-tags in the DB-module via a separate sanitize module.
However, be aware this functionality should be called prior to any markdown-related conversion in the future.
Otherwise, the resulting HTML will be encoded.
Related to https://github.com/ritterim/definely/issues/49.

Also added a new gulp task for running TDD-style tests.
And, incorporated this into the existing test-task.