### PR TITLE
Add markdown support when viewing terms via web client

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "handlebars": "~2.0.0",
     "hapi": "~8.1.0",
     "lazy.js": "^0.4.0",
+    "marked": "^0.3.3",
     "node-pg-migrate": "0.0.7",
     "pg": "^4.2.0",
     "request": "^2.51.0",

--- a/src/database.js
+++ b/src/database.js
@@ -1,12 +1,10 @@
 import pg from 'pg';
 import Term from './models/Term'
-import Sanitize from './sanitize'
 
 export
 default class Database {
     constructor(connectionUri) {
         this.connectionUri = connectionUri;
-        this.sanitize = new Sanitize();
     };
 
     add(term, callback) {
@@ -29,8 +27,6 @@ default class Database {
     };
 
     find(id, callback) {
-        var self = this;
-
         pg.connect(this.connectionUri, function (err, client, done) {
             if (err) {
                 return console.error('Could not connect to postgres', err);
@@ -48,7 +44,7 @@ default class Database {
                     var term = null
                     if (result.rows.length > 0) {
                         var row = result.rows[0]
-                        term = new Term(row.id, row.term, self.sanitize.htmlSanitize(row.definition), row.tags || undefined)
+                        term = new Term(row.id, row.term, row.definition, row.tags || undefined)
                     }
                     callback(term);
                 });
@@ -56,21 +52,18 @@ default class Database {
     };
 
     search(searchTerm, callback) {
-        var self = this;
-
         pg.connect(this.connectionUri, function (err, client, done) {
             if (err) {
                 return console.error('Could not connect to postgres', err);
                 done(client);
             }
 
-
             searchTerm = (searchTerm || '').trim().replace(/\s+/g, ' | ');
 
             if (!searchTerm) {
                 client.query('select id, term, tags, definition from terms', function (err, result) {
 
-                    var terms = result.rows.map(row => new Term(row.id, row.term, self.sanitize.htmlSanitize(row.definition), row.tags || undefined))
+                    var terms = result.rows.map(row => new Term(row.id, row.term, row.definition, row.tags || undefined))
                     callback(terms)
                 })
             } else {
@@ -82,7 +75,7 @@ default class Database {
                         }
 
                         done();
-                        var terms = result.rows.map(row => new Term(row.id, row.term, self.sanitize.htmlSanitize(row.definition), row.tags || undefined))
+                        var terms = result.rows.map(row => new Term(row.id, row.term, row.definition, row.tags || undefined))
                         callback(terms);
                     })
             }

--- a/src/handlebars-helpers.js
+++ b/src/handlebars-helpers.js
@@ -1,0 +1,46 @@
+import marked from 'marked'
+import Sanitize from './sanitize'
+
+export default class HandlebarsHelpers {
+    constructor(handlebars) {
+        this.handlebars = handlebars;
+    }
+
+    /**
+     * Singular call to register any available helpers.
+     */
+    register() {
+        this.registerCurrentYear(this.handlebars);
+        this.registerSanitizeHtml(this.handlebars);
+        this.registerMarked(this.handlebars);
+    }
+
+    /**
+     * Registers a helper which returns the current year.
+     */
+    registerCurrentYear(handlebars) {
+        handlebars.registerHelper("currentYear", function() {
+            return new Date().getFullYear();
+        });
+    }
+
+    /**
+     * Registers a helper which converts any HTML-brackets to their
+     * entity-versions.
+     */
+    registerSanitizeHtml(handlebars) {
+        handlebars.registerHelper('sanitizeHtml', function(input) {
+            return new Sanitize().sanitizeHtml(input);
+        });
+    }
+
+    /**
+     * Registers a helper for converting markdown into HTML via
+     * `marked` NPM.
+     */
+    registerMarked(handlebars) {
+        handlebars.registerHelper('marked', function(input) {
+            return marked(input);
+        });
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,12 @@ import _ from './extensions'
 import Lazy from 'lazy.js'
 import Handlebars from 'handlebars';
 import config from '../config'
-
-Handlebars.registerHelper("currentYear", function() {
-    return new Date().getFullYear();
-});
+import HandlebarsHelpers from './handlebars-helpers'
 
 console.log(config)
+
+// We want to register any app.-related helpers which can be called from associated views.
+new HandlebarsHelpers(Handlebars).register();
 
 spawnServer('App', config.port, registerControllers, {
     engines: {

--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -6,7 +6,7 @@ export default class Sanitize {
      * This function replaces all instances of lt and gt with their
      * HTML entity.
      */
-    htmlSanitize(html) {
+    sanitizeHtml(html) {
         html = html.replace(/</g, '&lt;');
         html = html.replace(/>/g, '&gt;');
 

--- a/src/sanitizeTests.js
+++ b/src/sanitizeTests.js
@@ -5,7 +5,7 @@ suite('Sanitize', function() {
     suite('#htmlSanitize()', function() {
         test('should encode all lt and gt-symbols', function() {
             var result = new sut()
-                .htmlSanitize('<test></test>');
+                .sanitizeHtml('<test></test>');
 
             assert.equal('&lt;test&gt;&lt;/test&gt;', result);
         });

--- a/src/views/terms/edit.hbs
+++ b/src/views/terms/edit.hbs
@@ -14,6 +14,9 @@
             <div class="col-md-12 form-group">
                 <label for="definition">Definition</label>
                 <textarea id="definition" name="definition" rows="10" class="form-control" placeholder="What does this term mean?">{{term.definition}}</textarea>
+                <p class="help-block">
+                    Markdown is supported. See <a href="http://daringfireball.net/projects/markdown/syntax">Daring Fireball's site</a> and <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub's site</a> for more information. Regular HTML is <strong>not</strong> supported.
+                </p>
             </div>
         </div>
         <div class="row text-right">

--- a/src/views/terms/new.hbs
+++ b/src/views/terms/new.hbs
@@ -14,6 +14,9 @@
             <div class="col-md-12 form-group">
                 <label for="definition">Definition</label>
                 <textarea id="definition" name="definition" rows="10" class="form-control" placeholder="What does {{term}}{{^term}}this term{{/term}} mean?"></textarea>
+                <p class="help-block">
+                    Markdown is supported. See <a href="http://daringfireball.net/projects/markdown/syntax">Daring Fireball's site</a> and <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub's site</a> for more information. Regular HTML is <strong>not</strong> supported.
+                </p>
             </div>
         </div>
         <div class="row text-right">

--- a/src/views/terms/show.hbs
+++ b/src/views/terms/show.hbs
@@ -7,6 +7,6 @@
         </small>
     </h3>
     <blockquote>
-        <p>{{{term.definition}}}</p>
+        {{{marked (sanitizeHtml term.definition)}}}
     </blockquote>
 </div>


### PR DESCRIPTION
Add new set of handlebars helpers and refactor existing helper into new module.
Update terms/show view to sanitize HTML and convert result into HTML via marked NPM.
Also refactor database module related to https://github.com/ritterim/definely/pull/51.
New behavior expects any sanitizing to be client-specific.
Related to https://github.com/ritterim/definely/issues/54 and https://github.com/ritterim/definely/issues/53.

New output related to the latter issue:
![image](https://cloud.githubusercontent.com/assets/3382469/5907870/85e43154-a570-11e4-86ae-3d784cd93fef.png)

Updated help-text related to markdown support:
![image](https://cloud.githubusercontent.com/assets/3382469/5908174/2fb7c27a-a573-11e4-8686-0b67bdf038b2.png)

