### PR TITLE
Fix missing property on DB-module search results

### DIFF
--- a/src/controllers/TermsController.js
+++ b/src/controllers/TermsController.js
@@ -27,9 +27,16 @@ default class TermsController extends Controller {
             if (terms.length === 1)
                 reply.redirect('/terms/' + terms[0].id)
             else {
-                var terms = Lazy(terms).sortBy(term => !searchTerm ? term.term : term.rank)
+                /**
+                 * Sorting is determined based on whether we have a search term.
+                 * With no search term, we will sort by `term.term` in ascending order.
+                 * With a search term, we will sort by `term.rank` in descending order.
+                 * This latter behavior is because higher ranking-values indicate
+                 * closer matches to the search term.
+                 */
+                var terms = Lazy(terms).sortBy(term => !searchTerm ? term.term : term.rank, !searchTerm ? false : true)
                     .map(t => {
-                        t.rankClass = !searchTerm || t.rank >= .8 ? 'text-success' : t.rank >= .5 ? 'text-warning' : t.rank >= .1 ? 'text-info' : 'text-danger'
+                        t.rankClass = !searchTerm || t.rank >= .8 ? 'text-success' : (t.rank >= .5 ? 'text-warning' : (t.rank >= .1 ? 'text-info' : 'text-danger'))
                         t.tags = t.tags.join(' ')
                         return t
                     }).toArray()

--- a/src/database.js
+++ b/src/database.js
@@ -75,7 +75,18 @@ default class Database {
                         }
 
                         done();
-                        var terms = result.rows.map(row => new Term(row.id, row.term, row.definition, row.tags || undefined))
+                        var terms = result.rows.map(row => {
+                            var term = new Term(row.id, row.term, row.definition, row.tags || undefined);
+
+                            /**
+                             * This property is dynamically added since it's specific
+                             * to this function and not part of the model.
+                             */
+                            term.rank = row.rank;
+
+                            return term;
+                        });
+
                         callback(terms);
                     })
             }


### PR DESCRIPTION
Previous behavior introduced a regression (based on ritterim@f3f44b3) which did not add the term's rank related to the DB-module's search function.
New behavior re-introduces this property.
This behavior also properly orders results in asc./desc. order based on whether a search term is given.
Also, logic in the TermsController related to setting a class-value has been updated to group ternary statements.
This is just for readability.

Related to #56.

Expected output:
![image](https://cloud.githubusercontent.com/assets/3382469/5911417/5e751d04-a593-11e4-965f-55eb2e9d94ba.png)

