### PR TITLE
Refactor terms-related views

### DIFF
--- a/src/controllers/HomeController.js
+++ b/src/controllers/HomeController.js
@@ -7,6 +7,9 @@ export default class HomeController extends Controller {
     }
 
     index(request, reply) {
-        reply.view('index')
+        // This is a special view and should not have a layout.
+        reply.view('index', {}, {
+            layout: false
+        })
     }
 }

--- a/src/controllers/TermsController.js
+++ b/src/controllers/TermsController.js
@@ -36,7 +36,6 @@ default class TermsController extends Controller {
                  */
                 var terms = Lazy(terms).sortBy(term => !searchTerm ? term.term : term.rank, !searchTerm ? false : true)
                     .map(t => {
-                        t.rankClass = !searchTerm || t.rank >= .8 ? 'text-success' : (t.rank >= .5 ? 'text-warning' : (t.rank >= .1 ? 'text-info' : 'text-danger'))
                         t.tags = t.tags.join(' ')
                         return t
                     }).toArray()

--- a/src/database.js
+++ b/src/database.js
@@ -67,7 +67,7 @@ default class Database {
                     callback(terms)
                 })
             } else {
-                client.query('select id, term, tags, definition, rank from terms, to_tsquery($1) as query, ts_rank_cd(weightedVector, query) as rank where weightedVector @@ query order by rank desc;', [searchTerm],
+                client.query('select id, term, tags, definition, rank, ts_headline(definition, query) as highlight_definition from terms, to_tsquery($1) as query, ts_rank_cd(weightedVector, query) as rank where weightedVector @@ query order by rank desc;', [searchTerm],
                     function (err, result) {
                         if (err) {
                             return console.error('Error running query', err);
@@ -83,6 +83,7 @@ default class Database {
                              * to this function and not part of the model.
                              */
                             term.rank = row.rank;
+                            term.highlightDefinition = row.highlight_definition;
 
                             return term;
                         });

--- a/src/handlebars-helpers.js
+++ b/src/handlebars-helpers.js
@@ -13,6 +13,7 @@ export default class HandlebarsHelpers {
         this.registerCurrentYear(this.handlebars);
         this.registerSanitizeHtml(this.handlebars);
         this.registerMarked(this.handlebars);
+        this.registerAddEllipsis(this.handlebars);
     }
 
     /**
@@ -41,6 +42,27 @@ export default class HandlebarsHelpers {
     registerMarked(handlebars) {
         handlebars.registerHelper('marked', function(input) {
             return marked(input);
+        });
+    }
+
+    /**
+     * Registers a helper for surrounding input with ellipsis
+     * depending on conditions of first and last-characters.
+     */
+    registerAddEllipsis(handlebars) {
+        handlebars.registerHelper('addEllipsis', function(input) {
+            var firstCharacter = input.charAt(0);
+            var lastCharacter = input.charAt(input.lenth - 1);
+
+            if (firstCharacter !== firstCharacter.toUpperCase()) {
+                input = '&hellip;' + input;
+            }
+
+            if (lastCharacter !== '.') {
+                input = input + '&hellip;';
+            }
+
+            return input;
         });
     }
 }

--- a/src/views/index.hbs
+++ b/src/views/index.hbs
@@ -1,18 +1,37 @@
-<div class="container text-center">
-    <div class="col-md-6 col-md-offset-3">
-        <form action="/terms">
-            <div class="form-group">
-                <div class="input-group">
-                    <input class="form-control" name="search-term" placeholder="What are you looking for?" autofocus />
-                    <a href="/terms/new" class="btn btn-success input-group-addon">
-                        <i class="glyphicon glyphicon-plus"></i>
-                        New term
-                    </a>
-                </div>
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>definely</title>
+        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
+    </head>
+    <body>
+        <div class="col-xs-12 text-center">
+            <h1>
+                <a href="/">
+                    <i class="glyphicon glyphicon-book"></i>&nbsp;definely
+                </a>
+            </h1>
+        </div>
+        <div class="container text-center">
+            <div class="col-md-6 col-md-offset-3">
+                <form action="/terms">
+                    <div class="form-group">
+                        <div class="input-group">
+                            <input class="form-control" name="search-term" placeholder="What are you looking for?" autofocus />
+                            <a href="/terms/new" class="btn btn-success input-group-addon">
+                                <i class="glyphicon glyphicon-plus"></i>
+                                New term
+                            </a>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <button class="btn btn-primary">Search</button>
+                    </div>
+                </form>
             </div>
-            <div class="form-group">
-                <button class="btn btn-primary">Search</button>
-            </div>
-        </form>
-    </div>
-</div>
+        </div>
+        <div class="container-fluid text-center">
+            {{> footer}}
+        </div>
+    </body>
+</html>

--- a/src/views/layouts/layout.hbs
+++ b/src/views/layouts/layout.hbs
@@ -7,6 +7,8 @@
     <body>
         {{> header}}
         {{{content}}}
-        {{> footer}}
+        <div class="container-fluid text-center">
+            {{> footer}}
+        </div>
     </body>
 </html>

--- a/src/views/partials/footer.hbs
+++ b/src/views/partials/footer.hbs
@@ -1,4 +1,2 @@
-<div class="text-center">
-    <hr />
-    <small>&copy; {{currentYear}}, <a href="https://www.ritterim.com/">Ritter Insurance Marketing</a></small>
-</div>
+<hr />
+<small>&copy; {{currentYear}}, <a href="https://www.ritterim.com/">Ritter Insurance Marketing</a></small>

--- a/src/views/partials/header.hbs
+++ b/src/views/partials/header.hbs
@@ -1,7 +1,21 @@
-<div class="col-xs-12 text-center">
-    <h1>
-        <a href="/">
-            <i class="glyphicon glyphicon-book"></i>&nbsp;definely
-        </a>
-    </h1>
-</div>
+<nav class="navbar navbar-default">
+    <div class="container-fluid">
+        <div class="navbar-header">
+            <a href="/" class="navbar-brand">
+                <i class="glyphicon glyphicon-book"></i>&nbsp;definely
+            </a>
+        </div>
+        <form class="navbar-form" action="/terms">
+            <div class="input-group col-md-6">
+                <input class="form-control" name="search-term" placeholder="What are you looking for?" value="{{searchTerm}}" autofocus />
+                <span class="input-group-btn">
+                    <button class="btn btn-primary">Search</button>
+                    <a href="/terms/new" class="btn btn-success">
+                        <i class="glyphicon glyphicon-plus"></i>
+                        New term
+                    </a>
+                </span>
+            </div>
+        </form>
+    </div>
+</nav>

--- a/src/views/terms/index.hbs
+++ b/src/views/terms/index.hbs
@@ -1,26 +1,39 @@
-<div class="container">
-    <h3>Search results for <kbd>{{searchTerm}}</kbd></h3>
-    <table class="table table-striped table-bordered">
-        <tbody>
-            {{#each terms}}
-            <tr>
-                <td>
-                    <i class="glyphicon glyphicon-book {{this.rankClass}}"></i>
-                    <a href="/terms/{{this.id}}">{{this.term}}</a>
-
-                    <a href="/terms/{{this.id}}/edit" title="Edit">
-                        <i class="glyphicon glyphicon-edit pull-right"></i>
-                    </a>
-                    <div class="clearfix"></div>
-                </td>
-            </tr>
-            {{else}}
-            <tr>
-                <td>
-                    No results found. You should <a href="/terms/new?term={{searchTerm}}">create a new entry for <kbd>{{searchTerm}}</kbd></a>.
-                </td>
-            </tr>
-            {{/each}}
-        </tbody>
-    </table>
+<div class="container-fluid">
+    <div class="col-lg-5 col-md-7">
+        <table class="table table-striped table-bordered">
+            <tbody>
+                {{#each terms}}
+                <tr>
+                    <td>
+                        <div class="row">
+                            <div class="col-xs-11">
+                                <strong>
+                                    <h4><a href="/terms/{{this.id}}">{{this.term}}</a></h4>
+                                </strong>
+                            </div>
+                            <div class="col-xs-1 text-right">
+                                <a href="/terms/{{this.id}}/edit" title="Edit">
+                                    <i class="glyphicon glyphicon-edit"></i>
+                                </a>
+                            </div>
+                        </div>
+                        {{#if this.highlightDefinition}}
+                        <div class="row">
+                            <div class="col-xs-12">
+                                {{{addEllipsis this.highlightDefinition}}}
+                            </div>
+                        </div>
+                        {{/if}}
+                    </td>
+                </tr>
+                {{else}}
+                <tr>
+                    <td>
+                        No results found. You should <a href="/terms/new?term={{searchTerm}}">create a new entry for <kbd>{{searchTerm}}</kbd></a>.
+                    </td>
+                </tr>
+                {{/each}}
+            </tbody>
+        </table>
+    </div>
 </div>

--- a/src/views/terms/show.hbs
+++ b/src/views/terms/show.hbs
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container-fluid">
     <h3>What is <kbd>{{term.term}}</kbd>?
         <small>
             <a href="/terms/{{term.id}}/edit" title="Edit">


### PR DESCRIPTION
New behavior removes icons from search results view designating rank of result.
New behavior uses pre-existing sorting of best-match results
Overall layout has been updated to include ability to search/add from all views.
Previous behavior only allowed this from home page.
Also add term-definition snippet to search result based on postgres ts_headline function.
New results are also left-aligned versus previous behavior of making everything centered.
Related to https://github.com/ritterim/definely/issues/59.

#### New search results:
![image](https://cloud.githubusercontent.com/assets/3382469/5929599/31de85a8-a653-11e4-9a4d-257c9e510d9a.png)

#### Individual term view:
![image](https://cloud.githubusercontent.com/assets/3382469/5929585/f9a8301c-a652-11e4-84f1-5b886664f483.png)
