### PR TITLE
Add some basic open graph tags

### DIFF
--- a/src/controllers/TermsController.js
+++ b/src/controllers/TermsController.js
@@ -68,7 +68,8 @@ export default class TermsController extends Controller {
         this._show(request.params.id).then(term =>
             reply.view('terms/show', {
                 title: 'Show term',
-                term: term
+                term: term,
+                hostUri: this.server.info.uri.trimEnd('/')
             }))
     }
 

--- a/src/handlebars-helpers.js
+++ b/src/handlebars-helpers.js
@@ -14,6 +14,7 @@ export default class HandlebarsHelpers {
         this.registerSanitizeHtml(this.handlebars);
         this.registerMarked(this.handlebars);
         this.registerAddEllipsis(this.handlebars);
+        this.registerSubstring(this.handlebars);
     }
 
     /**
@@ -63,6 +64,19 @@ export default class HandlebarsHelpers {
             }
 
             return input;
+        });
+    }
+
+    registerSubstring(handlebars) {
+        handlebars.registerHelper('substring', function(string, start, end, addEllipsis) {
+            var newString = string.substring(start, end);
+
+            // add ellipsis if length of string exceeds `end`-parameter and `addEllipsis` option is `true`.
+            if(string.length > end && addEllipsis) {
+                newString += '...';
+            }
+
+            return new handlebars.SafeString(newString);
         });
     }
 }

--- a/src/views/layouts/layout.hbs
+++ b/src/views/layouts/layout.hbs
@@ -3,6 +3,7 @@
     <head>
         <title>{{title}}{{^title}}definely{{/title}}</title>
         <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
+        {{> meta}}
     </head>
     <body>
         {{> header}}

--- a/src/views/partials/meta.hbs
+++ b/src/views/partials/meta.hbs
@@ -1,0 +1,8 @@
+{{#if term}}
+<meta property="og:title" content="What is `{{term.term}}`?" />
+<meta property="og:type" content="website" />
+{{#if hostUri}}
+<meta property="og:url" content="{{hostUri}}/terms/{{term.id}}" />
+{{/if}}
+<meta property="og:description" content="{{substring term.definition 0 100 true}}" />
+{{/if}}


### PR DESCRIPTION
These are read by a client to display meta-data about an individual term.
An example app. which reads this data is Slack (ref. https://api.slack.com/robots).

The expected behavior in Slack is when a term-link is posted to a channel, title and description term-data are shown below the post.

**Note**: there does not appear to be a way to test this locally within an app. like Slack, so this initial round may not work perfectly.
## Example demonstrating expected behavior using a link from nuget.org

![image](https://cloud.githubusercontent.com/assets/3382469/6498578/87a82726-c2bb-11e4-9973-394f5c6af84f.png)
